### PR TITLE
Fix to raise exceptions when commands are not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /coverage/
 /doc/
+/uploads/

--- a/lib/carrierwave/optimize_image/image_optimizer.rb
+++ b/lib/carrierwave/optimize_image/image_optimizer.rb
@@ -5,20 +5,12 @@ module CarrierWave
     module ImageOptimizer
       class << self
         def optimize(path, opts = {})
-          raise NotFoundPngquant unless which_pngquant?
-          raise NotFoundJpegoptim unless which_jpegoptim?
+          raise NotFoundPngquant if `which pngquant` == ""
+          raise NotFoundJpegoptim if `which jpegoptim` == ""
           optimize_for(path, opts)
         end
 
         private
-
-          def which_pngquant?
-            system! "which pngquant"
-          end
-
-          def which_jpegoptim?
-            system! "which jpegoptim"
-          end
 
           def optimize_for(path, opts)
             case mimetype(path)


### PR DESCRIPTION
I love pngquant too, thank you ;)

- Fix to raise `NotFoundPngquant` and `NotFoundJpegoptim` exceptions when commands are not found
- Hide standard output messages when checking to exist `pngquant` and `jpegoptim` commands like the following figure
- Ignore a directory `uploads`

![image](https://user-images.githubusercontent.com/20621562/28250827-d9b93654-6aac-11e7-8601-2aa61710139b.png)
